### PR TITLE
Feature/78 add switch host users

### DIFF
--- a/src/Pages/Likes/index.jsx
+++ b/src/Pages/Likes/index.jsx
@@ -1,15 +1,21 @@
 import LikesCard from "../../components/LikesCard";
 import { useSelector } from "react-redux";
 import styles from "./Likes.module.scss";
+import { useState, useEffect } from "react";
+import { httpGET } from "../../libs/http";
 
 const Likes = () => {
   const user = useSelector(state => state.user)
 
-  let dataLikes = { data: [], isRoom: 0 };
+  const [dataRoomLikes, setDataRoomLikes] = useState({ data: [], isRoom: 0 });
 
-  dataLikes = user.roomId.roomId !== ''
-    ? { data: user.roomId.wholikesme, isRoom: 0 }
-    : { data: user.wholikesme, isRoom: 1 };
+  useEffect(() => {
+    httpGET(`/users/${user._id}/wholikesmyroom`).then((data) => {
+      setDataRoomLikes({ data: data, isRoom: 0 }); // sono persone interessate alla stanza roomId
+    })
+  }, [user]);
+
+  const dataLikes = user.roomId.roomId !== '' ? dataRoomLikes : { data: user.wholikesme, isRoom: 1 };
 
   return (
     <div className={styles.main}>

--- a/src/Pages/Likes/index.jsx
+++ b/src/Pages/Likes/index.jsx
@@ -5,11 +5,17 @@ import styles from "./Likes.module.scss";
 const Likes = () => {
   const user = useSelector(state => state.user)
 
+  let dataLikes = { data: [], isRoom: 0 };
+
+  dataLikes = user.roomId.roomId !== ''
+    ? { data: user.roomId.wholikesme, isRoom: 0 }
+    : { data: user.wholikesme, isRoom: 1 };
+
   return (
     <div className={styles.main}>
       <div className={styles.cardContainer}>
-        {user.wholikesme.map((user, index) => (
-          <LikesCard key={index} user={user} />
+        {dataLikes.data.map((user, index) => (
+          <LikesCard key={index} user={user} isRoom={dataLikes.isRoom} />
         ))}
       </div>
     </div>

--- a/src/Pages/Main/index.jsx
+++ b/src/Pages/Main/index.jsx
@@ -8,12 +8,16 @@ import Matches from "../Matches";
 import Profile from "../Profile";
 import Users from "../Users";
 import RoomDetails from '../RoomDetails'
+import { useSelector } from "react-redux";
 
 const Main = () => {
+  const user = useSelector(state => state.user)
+
   return (
     <div className={styles.main}>
       <Header />
       <Routes>
+        <Route path="/list" element={user.roomId.roomId === '' ? <Rooms /> : <Users />} />
         <Route path="/rooms" element={<Rooms />} />
         <Route path="/likes" element={<Likes />} />
         <Route path="/matches" element={<Matches />} />
@@ -27,3 +31,4 @@ const Main = () => {
 };
 
 export default Main;
+

--- a/src/components/LikesCard/index.jsx
+++ b/src/components/LikesCard/index.jsx
@@ -1,15 +1,28 @@
 import styles from "./LikesCard.module.scss";
 
-const LikesCard = ({ user }) => {
+const LikesCard = ({ user, isRoom }) => {
   return (
     <div
       className={styles.cardContainer}
       style={{ backgroundImage: `url(${user.photo})` }}
     >
       <div className={styles.info}>
-        <p className={styles.name}>
-          {user.name} {user.surname}
-        </p>
+        {isRoom
+          ?
+          <>
+            <p className={styles.name}>
+              {user.roomType} Room
+            </p>
+            <p className={styles.name}>
+              in {user.roomAddress}
+            </p>
+          </>
+
+          :
+          <p className={styles.name}>
+            {user.name} {user.surname}
+          </p>
+        }
         <p className={styles.city}>{user.town} ({user.city})</p>
       </div>
     </div>

--- a/src/components/LikesCardInfo/index.jsx
+++ b/src/components/LikesCardInfo/index.jsx
@@ -6,7 +6,10 @@ import { IoIosCloseCircle } from "react-icons/io";
 import { FiHeart } from "react-icons/fi";
 // import { FaHeart } from "react-icons/fa";
 
-const LikesCardInfo = ({ user, showInfo, setShowInfo }) => {
+const LikesCardInfo = ({ user, showInfo, setShowInfo, isRoom }) => {
+
+  const dataDetails = isRoom ? user.friendlyWith : user.iam;
+
   return (
     <div className={styles.background}>
       <div className={styles.closeBtn} to="/">
@@ -19,7 +22,7 @@ const LikesCardInfo = ({ user, showInfo, setShowInfo }) => {
               {user.name} {user.surname}
             </h3>
             {console.log(user)}
-            <p>Age: {user.age}</p>
+            {!isRoom && <p>Age: {user.age}</p>}
             <p>
               {user.town} ({user.city})
             </p>
@@ -41,7 +44,7 @@ const LikesCardInfo = ({ user, showInfo, setShowInfo }) => {
                     type="checkbox"
                     name="action"
                     id="lgbtq"
-                    checked={user.iam.lgbtq === 1 ? true : false}
+                    checked={dataDetails.lgbtq === 1 ? true : false}
                   />
                   <span className={styles.mark}></span>
                 </label>
@@ -54,7 +57,7 @@ const LikesCardInfo = ({ user, showInfo, setShowInfo }) => {
                     readOnly
                     type="checkbox"
                     name="action"
-                    checked={user.iam.pet_owner === 1 ? true : false}
+                    checked={dataDetails.pet_owner === 1 ? true : false}
                     id="pet_owner"
                   />
                   <span className={styles.mark}></span>
@@ -71,7 +74,7 @@ const LikesCardInfo = ({ user, showInfo, setShowInfo }) => {
                     type="checkbox"
                     name="action"
                     id="multicultural"
-                    checked={user.iam.multicultural === 1 ? true : false}
+                    checked={dataDetails.multicultural === 1 ? true : false}
                   />
                   <span className={styles.mark}></span>
                 </label>
@@ -87,7 +90,7 @@ const LikesCardInfo = ({ user, showInfo, setShowInfo }) => {
                     type="checkbox"
                     name="action"
                     id="veg"
-                    checked={user.iam.veg === 1 ? true : false}
+                    checked={dataDetails.veg === 1 ? true : false}
                   />
                   <span className={styles.mark}></span>
                 </label>
@@ -101,7 +104,7 @@ const LikesCardInfo = ({ user, showInfo, setShowInfo }) => {
                     type="checkbox"
                     name="action"
                     id="smooker"
-                    checked={user.iam.smooker === 1 ? true : false}
+                    checked={dataDetails.smooker === 1 ? true : false}
                   />
                   <span className={styles.mark}></span>
                 </label>
@@ -115,7 +118,7 @@ const LikesCardInfo = ({ user, showInfo, setShowInfo }) => {
                     type="checkbox"
                     name="action"
                     id="party"
-                    checked={user.iam.party_lover === 1 ? true : false}
+                    checked={dataDetails.party_lover === 1 ? true : false}
                   />
                   <span className={styles.mark}></span>
                 </label>

--- a/src/components/MainNav/index.jsx
+++ b/src/components/MainNav/index.jsx
@@ -18,9 +18,9 @@ const MainNav = () => {
   return (
     <div className={styles.main}>
       <ul>
-        <Link to={"/rooms"}>
+        <Link to={"/list"}>
           <li>
-            {url.pathname === "/rooms" ? (
+            {url.pathname === "/list" ? (
               <img
                 src={roomatchFill}
                 style={{ height: 32, width: 32 }}


### PR DESCRIPTION
## Add switch Rooms List/Users List according to the logged user's role

- rename the path in generic `/list`
- update the route on path `/list` to render **_Rooms_** or **_Users_** (according to the logged user's role)
- update **_LikesCard_** component to render different data for room
- update _**Likes**_ page to switch between rooms/users according to the logged user
- add room/user handler in likes section


Closes: [ISSUE n. 78 ](https://github.com/ilPhil/roomatch/issues/78)


- [ X] New feature (non-breaking change which adds functionality)
