### PR TITLE
feat: add age value in user card (list and likes)

### DIFF
--- a/src/components/UserCard/index.jsx
+++ b/src/components/UserCard/index.jsx
@@ -105,10 +105,10 @@ const UserCard = ({ setResult, userInfo }) => {
             <div className={styles.headerCardInfo}>
               <div className={styles.title}>
                 <h3>
-                  {userInfo.name} {userInfo.surname}
+                  {userInfo.name} {userInfo.surname}, {userInfo.age}
                 </h3>
                 <p>
-                  {userInfo.town} ({userInfo.city})
+                  from {userInfo.town} ({userInfo.city})
                 </p>
               </div>
               <div className={styles.likeBtn}>


### PR DESCRIPTION
## Description
Add the data `age` in the **User** **card** for:
- `users` list
- `likes` list

Closes: [ISSUE n. 164 ](https://github.com/ilPhil/roomatch/issues/164)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
